### PR TITLE
Defer init of database connection

### DIFF
--- a/src/WikiCronManager.php
+++ b/src/WikiCronManager.php
@@ -18,8 +18,8 @@ class WikiCronManager {
 	protected $lb;
 
 	/**
-	*  @var array
-	*/
+	 * @var array
+	 */
 	private $registry = [];
 
 	/**


### PR DESCRIPTION
As registration of crons is done at `MediaWikiServices` time, a pre-mature access of the database connection can render "shared database" configuration impossible.